### PR TITLE
Guard against themes without colorAccent defined

### DIFF
--- a/src/com/android/settings/applications/AppOpsSummary.java
+++ b/src/com/android/settings/applications/AppOpsSummary.java
@@ -18,6 +18,8 @@ package com.android.settings.applications;
 
 import android.app.Fragment;
 import android.app.FragmentManager;
+import android.content.Context;
+import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.os.Bundle;
 import android.preference.PreferenceFrameLayout;
@@ -25,6 +27,7 @@ import android.support.v13.app.FragmentPagerAdapter;
 import android.support.v4.view.PagerTabStrip;
 import android.support.v4.view.ViewPager;
 import android.view.LayoutInflater;
+import android.util.TypedValue;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -35,7 +38,7 @@ import com.android.settings.R;
 public class AppOpsSummary extends InstrumentedPreferenceFragment {
     // layout inflater object used to inflate views
     private LayoutInflater mInflater;
-    
+
     private ViewGroup mContentContainer;
     private View mRootView;
     private ViewPager mViewPager;
@@ -116,14 +119,13 @@ public class AppOpsSummary extends InstrumentedPreferenceFragment {
         // HACK - https://code.google.com/p/android/issues/detail?id=213359
         ((ViewPager.LayoutParams)tabs.getLayoutParams()).isDecor = true;
 
-        // This should be set in the XML layout, but PagerTabStrip lives in
-        // support-v4 and doesn't have styleable attributes.
-        final TypedArray ta = tabs.getContext().obtainStyledAttributes(
-                new int[] { android.R.attr.colorAccent });
-        final int colorAccent = ta.getColor(0, 0);
-        ta.recycle();
-
-        tabs.setTabIndicatorColorResource(colorAccent);
+        Resources.Theme theme = tabs.getContext().getTheme();
+        TypedValue typedValue = new TypedValue();
+        theme.resolveAttribute(android.R.attr.colorAccent, typedValue, true);
+        final int colorAccent = typedValue.resourceId != 0
+                ? getContext().getColor(typedValue.resourceId)
+                : getContext().getColor(R.color.fingerprint_title_area_bg);
+        tabs.setTabIndicatorColor(colorAccent);
 
         // We have to do this now because PreferenceFrameLayout looks at it
         // only when the view is added.


### PR DESCRIPTION
If an applied theme omits the colorAccent attribute in their style
AppOpsSummary will crash because typedValue.resourceId is 0.

Check if typedValue.resourceId is 0 and if so use switch_accent_color
for tab indicator color.

Change-Id: Idc1ac94053d46515ec74797a7a149cbc4d0ce98b